### PR TITLE
Add file input dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   Made text input box use a monospace font
 -   Disabled download buttons when there is no input/output.
+-   Added a modal to the file input section.
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   Made text input box use a monospace font
 -   Disabled download buttons when there is no input/output.
--   Added a modal to the file input section.
+-   Added a dialog to the file input section.
 
 ### 🔧 Internal changes
 

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -59,7 +59,6 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
             fileReader.onload = (event) => {
                 const fileString = event.target.result as string;
                 setUploadedFileString(fileString);
-                props.setTextData(fileString);
             };
         } catch (error) {
             const errorMessage = `Error reading uploaded file as text. Please ensure it's in UTF-8 encoding: ${error.message}`;
@@ -85,6 +84,7 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                         position: "absolute",
                         top: "40%",
                         left: "20%",
+                        width: "50%",
                         backgroundColor: "white",
                         borderRadius: 1,
                     }}
@@ -106,10 +106,10 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                         />
                         <Button
                             data-testid="file-input-reapply-button"
-                            variant="contained"
+                            variant="text"
                             disabled={!uploadedFileString}
                             onClick={onLoadButtonClick}
-                            sx={{ textTransform: "none" }}
+                            sx={{ textTransform: "none", width: "30%" }}
                         >
                             Load file data
                         </Button>

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -11,8 +11,6 @@ import {
     Stack,
     Modal,
     Paper,
-    Card,
-    CardContent,
 } from "@mui/material";
 import DownloadJSONButton from "./DownloadJSONButton";
 import MemoryModelsMenu from "./MemoryModelsMenu";
@@ -79,7 +77,7 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
     return (
         <div>
             <Button onClick={handleOpen} sx={{ textTransform: "none" }}>
-                File Input
+                Upload JSON File
             </Button>
             <Modal
                 open={open}

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -9,6 +9,7 @@ import {
     Tooltip,
     MenuItem,
     Stack,
+    Modal,
 } from "@mui/material";
 import DownloadJSONButton from "./DownloadJSONButton";
 import MemoryModelsMenu from "./MemoryModelsMenu";
@@ -46,6 +47,10 @@ type MemoryModelsUserInputPropTypes = MemoryModelsFileInputPropTypes &
 
 function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
     const [uploadedFileString, setUploadedFileString] = useState("");
+    const [open, setOpen] = useState(false);
+
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
 
     const onChange = (event) => {
         try {
@@ -67,29 +72,52 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
 
     const onLoadButtonClick = () => {
         props.setTextData(uploadedFileString);
+        setOpen(false);
     };
 
     return (
-        <Stack direction={"row"} spacing={2}>
-            <Input
-                type="file"
-                onChange={onChange}
-                inputProps={{
-                    accept: "application/JSON",
-                    "data-testid": "file-input",
-                }}
-                disableUnderline={true}
-            />
-            <Button
-                data-testid="file-input-reapply-button"
-                variant="contained"
-                disabled={!uploadedFileString}
-                onClick={onLoadButtonClick}
-                sx={{ textTransform: "none" }}
-            >
-                Load file data
+        <div>
+            <Button onClick={handleOpen} sx={{ textTransform: "none" }}>
+                File Input
             </Button>
-        </Stack>
+            <Modal open={open} onClose={handleClose}>
+                <Box
+                    sx={{
+                        position: "absolute",
+                        top: "40%",
+                        left: "20%",
+                        backgroundColor: "white",
+                        borderRadius: 1,
+                    }}
+                >
+                    <Stack
+                        direction={"row"}
+                        spacing={2}
+                        padding={2}
+                        justifyContent={"space-between"}
+                    >
+                        <Input
+                            type="file"
+                            onChange={onChange}
+                            inputProps={{
+                                accept: "application/JSON",
+                                "data-testid": "file-input",
+                            }}
+                            disableUnderline={true}
+                        />
+                        <Button
+                            data-testid="file-input-reapply-button"
+                            variant="contained"
+                            disabled={!uploadedFileString}
+                            onClick={onLoadButtonClick}
+                            sx={{ textTransform: "none" }}
+                        >
+                            Load file data
+                        </Button>
+                    </Stack>
+                </Box>
+            </Modal>
+        </div>
     );
 }
 

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -79,32 +79,18 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                 File Input
             </Button>
             <Modal open={open} onClose={handleClose}>
-                <Box
-                    sx={{
-                        display: "flex",
-                        flexDirection: "row",
-                        position: "absolute",
-                        top: "40%",
-                        left: "20%",
-                        width: "50%",
-                        backgroundColor: "white",
-                        borderRadius: 1,
-                        justifyContent: "space-between",
-                        spacing: 2,
-                        padding: 2,
-                        alignItems: "center",
-                    }}
-                >
-                    <Input
-                        type="file"
-                        onChange={onChange}
-                        inputProps={{
-                            accept: "application/JSON",
-                            "data-testid": "file-input",
-                        }}
-                        disableUnderline={true}
-                        sx={{ alignContent: "center" }}
-                    />
+                <Box className="fileInputBox">
+                    <div>
+                        <Input
+                            type="file"
+                            onChange={onChange}
+                            inputProps={{
+                                accept: "application/JSON",
+                                "data-testid": "file-input",
+                            }}
+                            disableUnderline={true}
+                        />
+                    </div>
                     <div>
                         <Button
                             data-testid="file-input-reapply-button"

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -81,39 +81,42 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
             <Modal open={open} onClose={handleClose}>
                 <Box
                     sx={{
+                        display: "flex",
+                        flexDirection: "row",
                         position: "absolute",
                         top: "40%",
                         left: "20%",
                         width: "50%",
                         backgroundColor: "white",
                         borderRadius: 1,
+                        justifyContent: "space-between",
+                        spacing: 2,
+                        padding: 2,
+                        alignItems: "center",
                     }}
                 >
-                    <Stack
-                        direction={"row"}
-                        spacing={2}
-                        padding={2}
-                        justifyContent={"space-between"}
-                    >
-                        <Input
-                            type="file"
-                            onChange={onChange}
-                            inputProps={{
-                                accept: "application/JSON",
-                                "data-testid": "file-input",
-                            }}
-                            disableUnderline={true}
-                        />
+                    <Input
+                        type="file"
+                        onChange={onChange}
+                        inputProps={{
+                            accept: "application/JSON",
+                            "data-testid": "file-input",
+                        }}
+                        disableUnderline={true}
+                        sx={{ alignContent: "center" }}
+                    />
+                    <div>
                         <Button
                             data-testid="file-input-reapply-button"
-                            variant="text"
+                            variant="contained"
+                            color="primary"
                             disabled={!uploadedFileString}
                             onClick={onLoadButtonClick}
-                            sx={{ textTransform: "none", width: "30%" }}
+                            sx={{ textTransform: "none" }}
                         >
                             Load file data
                         </Button>
-                    </Stack>
+                    </div>
                 </Box>
             </Modal>
         </div>

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -81,7 +81,11 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
             <Button onClick={handleOpen} sx={{ textTransform: "none" }}>
                 File Input
             </Button>
-            <Modal open={open} onClose={handleClose}>
+            <Modal
+                open={open}
+                onClose={handleClose}
+                data-testid="file-input-modal"
+            >
                 <Paper
                     sx={{
                         position: "absolute",

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -10,6 +10,9 @@ import {
     MenuItem,
     Stack,
     Modal,
+    Paper,
+    Card,
+    CardContent,
 } from "@mui/material";
 import DownloadJSONButton from "./DownloadJSONButton";
 import MemoryModelsMenu from "./MemoryModelsMenu";
@@ -79,7 +82,15 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                 File Input
             </Button>
             <Modal open={open} onClose={handleClose}>
-                <Box className="fileInputBox">
+                <Paper
+                    sx={{
+                        position: "absolute",
+                        top: "40%",
+                        left: "20%",
+                        width: "50%",
+                        padding: 2,
+                    }}
+                >
                     <div>
                         <Input
                             type="file"
@@ -89,6 +100,7 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                                 "data-testid": "file-input",
                             }}
                             disableUnderline={true}
+                            sx={{ alignSelf: "center" }}
                         />
                     </div>
                     <div>
@@ -103,7 +115,7 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
                             Load file data
                         </Button>
                     </div>
-                </Box>
+                </Paper>
             </Modal>
         </div>
     );

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -9,8 +9,6 @@ import {
     Tooltip,
     MenuItem,
     Stack,
-    Modal,
-    Paper,
     Dialog,
     DialogActions,
     DialogContent,

--- a/demo/src/MemoryModelsUserInput.tsx
+++ b/demo/src/MemoryModelsUserInput.tsx
@@ -11,6 +11,9 @@ import {
     Stack,
     Modal,
     Paper,
+    Dialog,
+    DialogActions,
+    DialogContent,
 } from "@mui/material";
 import DownloadJSONButton from "./DownloadJSONButton";
 import MemoryModelsMenu from "./MemoryModelsMenu";
@@ -79,46 +82,36 @@ function MemoryModelsFileInput(props: MemoryModelsFileInputPropTypes) {
             <Button onClick={handleOpen} sx={{ textTransform: "none" }}>
                 Upload JSON File
             </Button>
-            <Modal
+            <Dialog
                 open={open}
                 onClose={handleClose}
-                data-testid="file-input-modal"
+                data-testid="file-input-dialog"
             >
-                <Paper
-                    sx={{
-                        position: "absolute",
-                        top: "40%",
-                        left: "20%",
-                        width: "50%",
-                        padding: 2,
-                    }}
-                >
-                    <div>
-                        <Input
-                            type="file"
-                            onChange={onChange}
-                            inputProps={{
-                                accept: "application/JSON",
-                                "data-testid": "file-input",
-                            }}
-                            disableUnderline={true}
-                            sx={{ alignSelf: "center" }}
-                        />
-                    </div>
-                    <div>
-                        <Button
-                            data-testid="file-input-reapply-button"
-                            variant="contained"
-                            color="primary"
-                            disabled={!uploadedFileString}
-                            onClick={onLoadButtonClick}
-                            sx={{ textTransform: "none" }}
-                        >
-                            Load file data
-                        </Button>
-                    </div>
-                </Paper>
-            </Modal>
+                <DialogContent>
+                    <Input
+                        type="file"
+                        onChange={onChange}
+                        inputProps={{
+                            accept: "application/JSON",
+                            "data-testid": "file-input",
+                        }}
+                        disableUnderline={true}
+                        sx={{ alignSelf: "center" }}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        data-testid="file-input-reapply-button"
+                        variant="contained"
+                        color="primary"
+                        disabled={!uploadedFileString}
+                        onClick={onLoadButtonClick}
+                        sx={{ textTransform: "none" }}
+                    >
+                        Load file data
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </div>
     );
 }

--- a/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
+++ b/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
@@ -133,9 +133,9 @@ describe("MemoryModelsUserInput", () => {
             jest.restoreAllMocks();
         });
 
-        it("does not render the modal when the page first loads", () => {
-            const modal = screen.queryByTestId("file-input-modal");
-            expect(modal).toBeNull();
+        it("does not render the dialog when the page first loads", () => {
+            const dialog = screen.queryByTestId("file-input-dialog");
+            expect(dialog).toBeNull();
 
             const input: HTMLInputElement = screen.queryByTestId("file-input");
             expect(input).toBeNull();

--- a/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
+++ b/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+    fireEvent,
+    getByText,
+    render,
+    screen,
+    waitFor,
+} from "@testing-library/react";
 import MemoryModelsUserInput from "../MemoryModelsUserInput";
 
 describe("MemoryModelsUserInput", () => {
@@ -127,7 +133,16 @@ describe("MemoryModelsUserInput", () => {
             jest.restoreAllMocks();
         });
 
+        it("does not render the modal when the page first loads", () => {
+            const modal = screen.queryByTestId("file-input-modal");
+            expect(modal).toBeNull();
+
+            const input: HTMLInputElement = screen.queryByTestId("file-input");
+            expect(input).toBeNull();
+        });
+
         it("renders an enabled input and disabled reapply button", () => {
+            fireEvent.click(screen.getByText("File Input"));
             const input: HTMLInputElement = screen.getByTestId("file-input");
             expect(input).toHaveProperty("disabled", false);
 
@@ -149,6 +164,7 @@ describe("MemoryModelsUserInput", () => {
                     type: "application/json",
                 }
             );
+            fireEvent.click(screen.getByText("File Input"));
             const input: HTMLInputElement = screen.getByTestId("file-input");
             await waitFor(() => {
                 // this needs to be awaited because of fileReader.onload being async
@@ -167,6 +183,7 @@ describe("MemoryModelsUserInput", () => {
             let input: HTMLInputElement;
 
             beforeEach(async () => {
+                fireEvent.click(screen.getByText("File Input"));
                 const file = new File([fileString], "test.json", {
                     type: "application/json",
                 });
@@ -198,10 +215,7 @@ describe("MemoryModelsUserInput", () => {
                     // once from reapplyBtn onChange, once from MemoryModelsTextInput handleTextFieldChange
                     // if put within the same waitFor block as fireEvent.click(reapplyBtn), this test always passes
                     // even with the wrong expect
-                    expect(setTextDataMock).toHaveBeenNthCalledWith(
-                        2,
-                        fileString
-                    );
+                    expect(setTextDataMock).toHaveBeenCalledWith(fileString);
                 });
             });
         });

--- a/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
+++ b/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
@@ -212,7 +212,6 @@ describe("MemoryModelsUserInput", () => {
                 });
 
                 await waitFor(() => {
-                    // once from reapplyBtn onChange, once from MemoryModelsTextInput handleTextFieldChange
                     // if put within the same waitFor block as fireEvent.click(reapplyBtn), this test always passes
                     // even with the wrong expect
                     expect(setTextDataMock).toHaveBeenCalledWith(fileString);

--- a/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
+++ b/demo/src/__tests__/MemoryModelsUserInput.spec.tsx
@@ -142,7 +142,7 @@ describe("MemoryModelsUserInput", () => {
         });
 
         it("renders an enabled input and disabled reapply button", () => {
-            fireEvent.click(screen.getByText("File Input"));
+            fireEvent.click(screen.getByText("Upload JSON File"));
             const input: HTMLInputElement = screen.getByTestId("file-input");
             expect(input).toHaveProperty("disabled", false);
 
@@ -164,7 +164,7 @@ describe("MemoryModelsUserInput", () => {
                     type: "application/json",
                 }
             );
-            fireEvent.click(screen.getByText("File Input"));
+            fireEvent.click(screen.getByText("Upload JSON File"));
             const input: HTMLInputElement = screen.getByTestId("file-input");
             await waitFor(() => {
                 // this needs to be awaited because of fileReader.onload being async
@@ -183,7 +183,7 @@ describe("MemoryModelsUserInput", () => {
             let input: HTMLInputElement;
 
             beforeEach(async () => {
-                fireEvent.click(screen.getByText("File Input"));
+                fireEvent.click(screen.getByText("Upload JSON File"));
                 const file = new File([fileString], "test.json", {
                     type: "application/json",
                 });

--- a/demo/src/css/styles.css
+++ b/demo/src/css/styles.css
@@ -20,3 +20,16 @@ input[type="number"]::-webkit-outer-spin-button {
     transition: transform 0.2s ease-in-out;
     transform: rotate(180deg);
 }
+
+.fileInputBox {
+    display: flex;
+    position: absolute;
+    top: 40%;
+    left: 20%;
+    width: 50%;
+    background-color: white;
+    border-radius: 5px;
+    justify-content: space-between;
+    padding: 10px;
+    align-items: center;
+}

--- a/demo/src/css/styles.css
+++ b/demo/src/css/styles.css
@@ -20,16 +20,3 @@ input[type="number"]::-webkit-outer-spin-button {
     transition: transform 0.2s ease-in-out;
     transform: rotate(180deg);
 }
-
-.fileInputBox {
-    display: flex;
-    position: absolute;
-    top: 40%;
-    left: 20%;
-    width: 50%;
-    background-color: white;
-    border-radius: 5px;
-    justify-content: space-between;
-    padding: 10px;
-    align-items: center;
-}


### PR DESCRIPTION
## Proposed Changes
Adds a modal to the file input section to clean up the user interface. 

...

<details>

current input section:

![image](https://github.com/user-attachments/assets/5edb8bf6-a788-402c-beac-5d921128b618)

input section following changes:

![image](https://github.com/user-attachments/assets/c4d1738a-464b-4661-8601-3446d2f801d9)

The Upload JSON File button opens a modal:

![image](https://github.com/user-attachments/assets/772853c2-c970-4829-999d-a7c3d8f8c050)


<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |     X    |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

-   [x] I have performed a self-review of my changes.
    -   Check that all changed files included in this pull request are intentional changes.
    -   Check that all changes are relevant to the purpose of this pull request, as described above.
-   [x] I have added tests for my changes, if applicable.
    -   This is **required** for all bug fixes and new features.
-   [ ] I have updated the project documentation, if applicable.
    -   This is **required** for new features.
-   [ ] If this is my first contribution, I have added myself to the list of contributors.
-   [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

-   [x] I have verified that the CI tests have passed.
-   [x] I have reviewed the test coverage changes reported by Coveralls.
-   [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

Hello Professor! I managed to get the button to a reasonable size without having to rewrite any classes, but I can't seem to vertically center the file browse button within the modal window  -- I included screenshots of this. From using the inspect tool, it seems like the file browse/input button is placed inside a div once the website is rendered but not centered within it. I'm not sure how to modify this div, or get rid of it. Do you have any suggestions on next steps? Thanks!
