### PR TITLE
Dark Mode Syntax Highlighting for Webstepper

### DIFF
--- a/webstepper/CHANGELOG.md
+++ b/webstepper/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### ✨ Enhancements
 
 - Added the MemoryViz logo as a favicon
+- Added dark mode syntax highlighting for the code display
 
 ### 🐛 Bug fixes
 

--- a/webstepper/src/App.tsx
+++ b/webstepper/src/App.tsx
@@ -82,6 +82,7 @@ export default function App({ isDarkMode, toggleTheme }: AppProps) {
                                 highlightLine={
                                     window.memoryVizData[step].lineNumber
                                 }
+                                isDarkMode={isDarkMode}
                             />
                         </Box>
                     </Stack>

--- a/webstepper/src/CodeDisplay.tsx
+++ b/webstepper/src/CodeDisplay.tsx
@@ -1,15 +1,20 @@
 import React from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
-import { a11yLight } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import {
+    a11yLight,
+    a11yDark,
+} from "react-syntax-highlighter/dist/esm/styles/hljs";
 import { Box } from "@mui/material";
 
 type CodeDisplayPropTypes = {
     text: string;
     startingLineNumber: number;
     highlightLine: number;
+    isDarkMode: boolean;
 };
 
 export default function CodeDisplay(props: CodeDisplayPropTypes) {
+    const a11yTheme = props.isDarkMode ? a11yDark : a11yLight;
     return (
         <Box className="code-display__code-box">
             <SyntaxHighlighter
@@ -19,10 +24,12 @@ export default function CodeDisplay(props: CodeDisplayPropTypes) {
                 startingLineNumber={props.startingLineNumber}
                 wrapLines={true}
                 wrapLongLines={true}
-                style={a11yLight}
+                style={a11yTheme}
                 lineProps={(lineNumber: number) => {
                     if (lineNumber == props.highlightLine) {
-                        return { className: "code-box__line--highlighted" };
+                        return {
+                            className: `code-box__line--highlighted${props.isDarkMode ? "-dark" : ""}`,
+                        };
                     }
                 }}
             >

--- a/webstepper/src/css/styles.scss
+++ b/webstepper/src/css/styles.scss
@@ -45,6 +45,10 @@ main {
     background-color: yellow;
 }
 
+.code-box__line--highlighted-dark {
+    background-color: #7b1b38;
+}
+
 .svg-display {
     flex: 1;
     margin-bottom: 1rem;

--- a/webstepper/src/css/styles.scss
+++ b/webstepper/src/css/styles.scss
@@ -11,6 +11,7 @@ h2 {
 
 pre > code {
     --spacing: 0.25rem;
+    color: unset;
 }
 
 html,

--- a/webstepper/src/index.tsx
+++ b/webstepper/src/index.tsx
@@ -108,7 +108,7 @@ const darkTheme = createTheme({
         },
         background: {
             default: "#121212",
-            paper: "#1e1e1e",
+            paper: "#151515",
         },
         text: {
             primary: "#e0e0e0",


### PR DESCRIPTION
## Proposed Changes

Import `a11yDark` as well as the already imported `a11yLight`, and have the `CodeDisplay` decide which styling to use based on the newly passed in prop `isDarkMode`.

Align the background grey colours in dark mode (the pre-existing `paper` colour and the colour rendered by `a11yDark` to be the same.

Ensure that the colour of the `<code>` text (that is not handled by the syntax highlighter) changes when changing from light to dark mode. This change does not change anything visually in light mode.

Highlight Colours:
<details>
  In dark mode, `a11yDark` has text render in grey, orange, and lilac. The goal is to find some complementary colour to highlight these items without drowning out the actual text.
  <div align="center">
  
  <img width="184" height="181" alt="Screenshot 2026-03-06 at 01 22 48" src="https://github.com/user-attachments/assets/865052a9-9e41-4094-b4b9-963eb3bf3f78" />
  </div>
  
  We can see that a middle ground between orange and violet/grey is red. And the compliment of this middle is turquoise.
  
  Using a vibrant red feels awkward because of the common idea that red = bad. So the choice that I think is the front runner for this ticket is a "merlot":

  <div align="center">
  
<img width="812" height="317" alt="Screenshot 2026-03-06 at 14 42 45" src="https://github.com/user-attachments/assets/52042a22-b87e-4d7c-9801-c6e6c6468274" />

  </div>

  Here are other iterations of what was tested, I personally believe they are less appealing to look at or they drown out certain items that `a11yDark` renders.
 
  <div align="center">
<img width="597" height="182" alt="Screenshot 2026-03-06 at 14 43 34" src="https://github.com/user-attachments/assets/912927d2-c93d-4572-a69f-d27b14a77845" />
<img width="600" height="225" alt="Screenshot 2026-03-06 at 14 44 21" src="https://github.com/user-attachments/assets/c282cadc-ac77-49cd-bb2a-af74c87eff03" />
<img width="598" height="194" alt="Screenshot 2026-03-06 at 14 45 20" src="https://github.com/user-attachments/assets/c0faaebc-cfc9-455a-94f8-ce00ba58b701" />
  
  The colour used in Light Mode:
  <img width="596" height="194" alt="Screenshot 2026-03-06 at 14 44 04" src="https://github.com/user-attachments/assets/7ae0a974-6ecf-4b66-80fa-cf5a4d8ddce8" />
  </div>
</details>

Background Colours:
<details>
Before:
<div align="center">
<img width="1337" height="622" alt="Screenshot 2026-03-06 at 14 48 49" src="https://github.com/user-attachments/assets/b7ae56e7-e9c0-401f-8cc5-5d2b79999c0e" />

</div>
After:
<div align="center">
<img width="1339" height="605" alt="Screenshot 2026-03-06 at 14 47 28" src="https://github.com/user-attachments/assets/abd2bb46-77dc-4a70-8239-ab2e8139a8d6" />

</div>
</details>

Dark Mode Code Text Colour:
<details>
Before:
<img width="1449" height="642" alt="Screenshot 2026-03-06 at 01 56 33" src="https://github.com/user-attachments/assets/a06e5c7f-2c33-4419-af60-2a3d33e182b7" />

After:
<img width="435" height="282" alt="Screenshot 2026-03-06 at 12 20 23" src="https://github.com/user-attachments/assets/e6402f01-6d5f-4209-82f1-4c699e6fb091" />
</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |     X    |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
    - This is **required** for new features.
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/david-yz-liu/memory-viz/blob/master/memory-viz/package.json).
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
