### PR TITLE
Release v0.9.0!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### ✨ Enhancements
 
+### 🐛 Bug fixes
+
+### 📚 Documentation and demo website changes
+
+### 🔧 Internal changes
+
+## [0.9.0] - 2026-05-23
+
+### ✨ Enhancements
+
 - Added the built in immutable Python types (complex, bytes, range) to the memory-viz immutable types
 - Added documentation and tests for the pre-existingly supported immutable Python type `datetime.date`
 - Added the built in immutable Python type `frozenset` to the memory-viz immutable, and sequence types

--- a/memory-viz/package.json
+++ b/memory-viz/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-viz",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "Library for creating beginner-friendly memory model diagrams.",
     "type": "module",
     "exports": {

--- a/webstepper/CHANGELOG.md
+++ b/webstepper/CHANGELOG.md
@@ -7,6 +7,18 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### 🚨 Breaking changes
+
+### ✨ Enhancements
+
+### 🐛 Bug fixes
+
+### 📚 Documentation changes
+
+### 🔧 Internal changes
+
+## [0.9.0] - 2026-05-23
+
 ### ✨ Enhancements
 
 - Added the MemoryViz logo as a favicon
@@ -14,13 +26,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `lang` attribute to root `<html>` element of webstepper website
 - Changed webstepper website subheading component to `<h2>` to ensure all heading elements are in sequentially decreasing order
 
-### 🐛 Bug fixes
-
 ### 🚨 Breaking changes
 
 - The webstepper now requires a list of JSONS containing line numbers, a MemoryViz input and (optionally) a configuration to be provided by a global variable. MemoryViz is then invoked directly to render these MemoryViz inputs into SVGs for display.
-
-### 📚 Documentation changes
 
 ### 🔧 Internal changes
 

--- a/webstepper/package.json
+++ b/webstepper/package.json
@@ -1,6 +1,6 @@
 {
     "name": "memory-viz-webstepper",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "An interactive web stepper for memory-viz",
     "type": "module",
     "scripts": {


### PR DESCRIPTION
This pull request bumps the `memory-viz` and `webstepper` package versions to 0.9.0.