### PR TITLE
Removed CodeDisplay line wrap

### DIFF
--- a/webstepper/CHANGELOG.md
+++ b/webstepper/CHANGELOG.md
@@ -12,6 +12,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### ✨ Enhancements
 
 - Added optional `startLineNumber` variable for custom line numbers, defaulting to first element of `memoryVizData` if not set
+- Removed line wrap and added a horizontal scrollbar for overflowing text to `CodeDisplay`
 
 ### 🐛 Bug fixes
 

--- a/webstepper/src/CodeDisplay.tsx
+++ b/webstepper/src/CodeDisplay.tsx
@@ -23,7 +23,6 @@ export default function CodeDisplay(props: CodeDisplayPropTypes) {
                 showLineNumbers={true}
                 startingLineNumber={props.startingLineNumber}
                 wrapLines={true}
-                wrapLongLines={true}
                 style={a11yTheme}
                 lineProps={(lineNumber: number) => {
                     if (lineNumber == props.highlightLine) {

--- a/webstepper/src/css/styles.scss
+++ b/webstepper/src/css/styles.scss
@@ -42,6 +42,11 @@ main {
     background-color: transparent;
 }
 
+.code-display__code-box > pre > code {
+    padding-right: 1em;
+    display: inline-block;
+}
+
 .code-box__line--highlighted {
     background-color: yellow;
 }


### PR DESCRIPTION
## Proposed Changes

Currently the `CodeDisplay` in Webstepper wraps long lines of code, which can hurt user experience. To improve the interface, remove line wrapping.

I also added some additional right padding to the code because the text would extend to the end of the display.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

<img width="1646" height="370" alt="image" src="https://github.com/user-attachments/assets/5a72e923-684d-46c8-9b61-d1242cc8c53e" />

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| 🎨 _User interface change_ (change to user interface; provide screenshots)              |     x     |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
    - Check that all changed files included in this pull request are intentional changes.
    - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
    - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
    - This is **required** for new features.
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/david-yz-liu/memory-viz/blob/master/memory-viz/package.json).
- [x] I have updated the project Changelog (this is required for all changes).

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
